### PR TITLE
Allow to supply an sender name for email notifications.

### DIFF
--- a/notifications/asciimail
+++ b/notifications/asciimail
@@ -86,7 +86,7 @@ def build_mail(target, subject, from_address, reply_to, content_txt):
 def send_mail(m, target, from_address):
     cmd = ["/usr/sbin/sendmail"]
     if from_address:
-        cmd += ['-f', from_address]
+        cmd += ['-F', from_address]
     cmd += [ "-i", target]
     p = subprocess.Popen(cmd, stdin = subprocess.PIPE)
     p.communicate(m.as_string())

--- a/notifications/mail
+++ b/notifications/mail
@@ -403,7 +403,7 @@ def multipart_mail(target, subject, from_address, reply_to, content_txt, content
 def send_mail(m, target, from_address):
     cmd = ["/usr/sbin/sendmail"]
     if from_address:
-        cmd += ['-f', from_address]
+        cmd += ['-F', from_address]
     cmd += [ "-i", target]
     try:
         p = subprocess.Popen(cmd, stdin = subprocess.PIPE)


### PR DESCRIPTION
From sendmail - Postfix to Sendmail compatibility interface:

> -F full_name
>               Set the sender full name. This overrides the NAME
>               environment variable, and is used only with messages
>               that have no From: message header.

Now it is possible to set the sender name via the rule based notifications in WATO like this:
From: Company Mointoring monitoring@example.com

Tested with sendmail compatibility version from postfix.

The patch has not yet been merged upstream. I opened the PR against this mirror to make the patch visible if others hit this problem.

Patch will be submitted upstream. Please pull from https://github.com/ypid/check_mk.git
