### PR TITLE
nginx_status plugin: Fixed try_detect_servers for IPv6 loopback.

### DIFF
--- a/agents/plugins/nginx_status
+++ b/agents/plugins/nginx_status
@@ -89,7 +89,7 @@ def try_detect_servers():
         if address == '0.0.0.0':
             address = '127.0.0.1'
         elif address == '::':
-            address = '::1'
+            address = '[::1]'
 
         # Switch protocol if port is SSL port. In case you use SSL on another
         # port you would have to change/extend the ssl_port list


### PR DESCRIPTION
Related to
https://github.com/debops-contrib/ansible-checkmk_agent/pull/3
- Also fixed it for apache_status.

Patch will be submitted upstream. Please pull from https://github.com/ypid/check_mk.git
