### PR TITLE
Added support Veeam Endpoint backup jobs to Windows agent plugin.

### DIFF
--- a/agents/windows/plugins/veeam_backup_status.ps1_
+++ b/agents/windows/plugins/veeam_backup_status.ps1_
@@ -62,7 +62,7 @@ foreach ($myJob in $myBackupJobs)
 
 	# For Non Backup Jobs (Replicas) we bail out
 	# because we are interested in the status of the original backup but
-	# for replicas the overall job state is all we need. 
+	# for replicas the overall job state is all we need.
         if ($myJob.IsBackup -eq $false) { continue }
 
 	# Each backup job has a number of tasks which were executed (VMs which were processed)
@@ -142,6 +142,29 @@ foreach ($myJob in $myBackupJobs)
 
 # END OF LOOP foreach ($myJob in $myBackupJobs)
 }
+
+
+# Get Endpoint backup jobs.
+$myVBREPBackupJobs = Get-VBREPJob
+
+# Iterate through all backup jobs
+foreach ($myJob in $myVBREPBackupJobs)
+{
+	$myJobName = ""
+	$myJobName = $myJob.Name -replace "\'","_" -replace " ","_"
+
+	$myJobType = ""
+	$myJobType = $myjob.Type
+
+	$myJobLastState = ""
+	$myJobLastState = $myJob.LastState
+
+	$myJobLastResult = ""
+	$myJobLastResult = $myJob.LastResult
+
+	$myJobsText = "$myJobsText" + "$myJobName" + "`t" + "$myJobType" + "`t" + "$myJobLastState" + "`t" + "$myJobLastResult" + "`n"
+}
+
 
 # Final output
 write-host $myJobsText


### PR DESCRIPTION
Example output of `Get-VBREPJob`:

```
RepositoryId : fa137044-0e1f-11e6-86b3-a77f5f0d70f0
ObjectsCount : 1
IsEnabled    : True
NextRun      : 26.09.2015 22:00:00
Target       : $target
Type         : EndpointBackup
LastResult   : Success
LastState    : Stopped
Id           : ef13e0b6-0e1f-11e6-842a-07b51a32dae7
Name         : Backup Job $hostname
Description  : Endpoint backup job
```

The `NextRun` value does not match the value shown in the Veeam GUI as
of Veeam 9.0.0.1491. This needs to be checked.
Compared to `Get-VBRJob`, `Get-VBRJob` does not seem to report job start
and stop times.

API docs:
https://helpcenter.veeam.com/backup/powershell/get-vbrepjob.html
